### PR TITLE
Combine highlights of overlapping matches

### DIFF
--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -1,78 +1,12 @@
 /* @flow */
 import React, { PropTypes } from 'react'
 import styles from './Highlighter.css'
+import * as Chunks from './utils.js'
 
 Highlighter.propTypes = {
   highlightClassName: PropTypes.string,
   searchWords: PropTypes.arrayOf(PropTypes.string).isRequired,
   textToHighlight: PropTypes.string.isRequired
-}
-
-/**
- * Takes an array of {start:number, end:number} objects and combines chunks that overlap into single chunks.
- */
-const combineChunks = (chunks) => {
-  chunks = chunks
-    .sort((first, second) => first.start - second.start)
-    .reduce((processedChunks, nextChunk) => {
-      // First chunk just goes straight in the array...
-      if (processedChunks.length === 0) {
-        return [nextChunk]
-      } else {
-        // ... subsequent chunks get checked to see if they overlap...
-        const prevChunk = processedChunks.pop()
-        if (nextChunk.start <= prevChunk.end) {
-          // It may be the case that prevChunk completely surrounds nextChunk, so take the
-          // largest of the end indeces.
-          const endIndex = Math.max(prevChunk.end, nextChunk.end)
-          processedChunks.push({start: prevChunk.start, end: endIndex})
-        } else {
-          processedChunks.push(prevChunk, nextChunk)
-        }
-        return processedChunks
-      }
-    }, [])
-
-  return chunks
-}
-
-/**
- * Examine textToSearch for any matches.
- * If we find matches, add them to the returned array as a "chunk" object ({start:number, end:number}).
- */
-const findChunks = (textToSearch, wordsToFind) =>
-  wordsToFind
-    .filter(searchWord => searchWord) // Remove empty words
-    .reduce((chunks, searchWord) => {
-        const regex = new RegExp(searchWord, 'gi')
-        let match
-        while ((match = regex.exec(textToSearch)) != null) {
-          chunks.push({start: match.index, end: regex.lastIndex})
-        }
-        return chunks
-    }, [])
-
-/**
- * Given a set of chunks to highlight, create an additional set of chunks
- * to represent the bits of text between the highlighted text.
- * @return {start:number, end:number, highlight:boolean}[]
- */
-const fillInChunks = (chunksToHighlight, totalLength) => {
-  const allChunks = []
-  const append = (start, end, highlight) => allChunks.push({start: start, end: end, highlight: highlight})
-
-  if (chunksToHighlight.length == 0) {
-	append(0, totalLength, false);
-  } else {
-    let lastIndex = 0
-    chunksToHighlight.forEach((chunk) => {
-      append(lastIndex, chunk.start, false)
-      append(chunk.start, chunk.end, true)
-      lastIndex = chunk.end
-    })
-    append(lastIndex, totalLength, false)
-  }
-  return allChunks
 }
 
 /**
@@ -84,7 +18,7 @@ export default function Highlighter ({
   searchWords,
   textToHighlight }
 ) {
-  const chunks = fillInChunks(combineChunks(findChunks(textToHighlight, searchWords)), textToHighlight.length)
+  const chunks = Chunks.findAll(searchWords, textToHighlight)
   const highlightClassNames = `${styles.Term} ${highlightClassName}`
   let uidCounter = 0
   const content = chunks.map((chunk) =>

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -9,6 +9,47 @@ Highlighter.propTypes = {
 }
 
 /**
+ * Takes an array of {start:number, end:number} objects and combines chunks that overlap into single chunks.
+ */
+const combineChunks = (chunks) => {
+  chunks = chunks
+    .sort((first, second) => first.start - second.start)
+    .reduce((processedChunks, nextChunk) => {
+      // First chunk just goes straight in the array...
+      if (processedChunks.length === 0) {
+        return [nextChunk]
+      } else {
+        // ... subsequent chunks get checked to see if they overlap...
+        const prevChunk = processedChunks.pop()
+        if (nextChunk.start <= prevChunk.end) {
+          processedChunks.push({start: prevChunk.start, end: nextChunk.end})
+        } else {
+          processedChunks.push(prevChunk, nextChunk)
+        }
+        return processedChunks
+      }
+    }, [])
+
+  return chunks
+}
+
+/**
+ * Examine textToSearch for any matches.
+ * If we find matches, add them to the returned array as a "chunk" object ({start:number, end:number}).
+ */
+const findChunks = (textToSearch, wordsToFind) =>
+  wordsToFind
+    .filter(searchWord => searchWord) // Remove empty words
+    .reduce((chunks, searchWord) => {
+        const regex = new RegExp(searchWord, 'gi')
+        let match
+        while ((match = regex.exec(textToSearch)) != null) {
+          chunks.push({start: match.index, end: regex.lastIndex})
+        }
+        return chunks
+    }, [])
+
+/**
  * Highlights all occurrences of search terms (searchText) within a string (textToHighlight).
  * This function returns an array of strings and <span>s (wrapping highlighted words).
  */

--- a/src/utils-tests.js
+++ b/src/utils-tests.js
@@ -1,0 +1,121 @@
+import * as Chunks from './utils.js'
+
+export const Tests = () => {
+
+    const assert = (boolValue, message) => {
+        if (!boolValue) {
+            throw new Error("Assertion failed" + (message == null ? '' : ': ' + message))
+        }
+    }
+
+    const findChunk = (chunks, start, end) =>
+        chunks.find((chunk) => chunk.start == start && chunk.end == end)
+
+    const assertChunks = (actualChunks, expectedChunks) => {
+        assert(actualChunks.length == expectedChunks.length, "Expected " + expectedChunks.length + ", got " + actualChunks.length)
+        expectedChunks.forEach((expected) => {
+            assert(findChunk(actualChunks, expected.start, expected.end) != null, "Couldn't find expected chunk: " + expected.start + ":" + expected.end)
+        })
+    }
+
+    /*
+     * Here is the TEXT string on one line starting at character 0, so you can use your text
+     * editor to calculate the expected offsets of qui/uam/isquam:
+
+Quae quo aut officiis voluptas exercitationem. Sapiente quod magni dolore cupiditate perferendis. Qui et ratione quisquam est. Similique et sint consequatur tenetur accusamus. Qui dolorum at quo voluptatum aliquam odit qui. Et alias velit deleniti doloremque esse adipisci autem.
+
+     */
+    const TEXT =
+        "Quae quo aut officiis voluptas exercitationem. " +
+        "Sapiente quod magni dolore cupiditate perferendis. " +
+        "Qui et ratione quisquam est. " +
+        "Similique et sint consequatur tenetur accusamus. " +
+        "Qui dolorum at quo voluptatum aliquam odit qui. " +
+        "Et alias velit deleniti doloremque esse adipisci autem."
+
+    const expectedQuiChunks = [
+        {start: 98, end: 101},
+        {start: 113, end: 116},
+        {start: 176, end: 179},
+        {start: 219, end: 222},
+    ];
+
+    const expectedUamChunks = [
+        {start: 118, end: 121},
+        {start: 210, end: 213},
+    ];
+
+    const expectedIsquamChunks = [
+        {start: 115, end: 121},
+    ];
+
+    // "qui"
+    // 4 occurrences of "qui" (some with capital "Q", others without).
+    // None of them cross.
+    (function() {
+        const rawChunks = Chunks.findChunks(TEXT, ["qui"])
+        assert(rawChunks.length == 4)
+        assertChunks(rawChunks, expectedQuiChunks)
+
+        const combinedChunks = Chunks.combineChunks(rawChunks)
+        assert(combinedChunks.length == 4)
+        assertChunks(combinedChunks, expectedQuiChunks)
+    })();
+
+    // "qui" + "uam"
+    // 4 + 2 occurrences, with no crossover.
+    (function() {
+        const expectedChunks = expectedQuiChunks.concat(expectedUamChunks)
+        const rawChunks = Chunks.findChunks(TEXT, ["qui", "uam"])
+        assert(rawChunks.length == expectedChunks.length)
+        assertChunks(rawChunks, expectedChunks)
+
+        const combinedChunks = Chunks.combineChunks(rawChunks)
+        assert(combinedChunks.length == expectedChunks.length, "After combining, expected 6 chunks, got: " + combinedChunks.length)
+        assertChunks(combinedChunks, expectedChunks)
+    })();
+
+    // "qui" + "isquam"
+    // There is 4 "qui" and one "isquam" occurrence.
+    // However, the "isquam" crosses over with a "qui", so there should only be
+    // a total of 4 results (one of which is "quisquam") when all is said and done.
+    (function() {
+        const rawChunks = Chunks.findChunks(TEXT, ["qui", "isquam"])
+        assert(rawChunks.length == 5);
+        assertChunks(rawChunks, expectedQuiChunks.concat(expectedIsquamChunks))
+
+        const expectedChunks = [
+            {start: 98, end: 101},
+            {start: 113, end: 121}, // This is from combining "qui" at 113:116 and "isquam" at 115:121
+            {start: 176, end: 179},
+            {start: 219, end: 222},
+        ]
+
+        const combinedChunks = Chunks.combineChunks(rawChunks)
+        assert(combinedChunks.length == 4)
+        assertChunks(combinedChunks, expectedChunks)
+
+        const assertCorrectHighlighted = (processedChunks) => {
+
+            // Check that all four matched chunks are marked as highlighted.
+            expectedChunks.forEach((chunk) => {
+                const found = findChunk(processedChunks, chunk.start, chunk.end)
+                assert(found != null)
+                assert(found.highlight, `Expected chunk ${chunk.start}:${chunk.end} to be highlighted, it wasn't`)
+            })
+
+            // Then check all other chunks, and ensure they are not the highlighted ones.
+            assert(
+                processedChunks
+                    .filter((chunk) => !chunk.highlight && findChunk(expectedChunks, chunk.start, chunk.end) == null)
+                    .length == 5
+            )
+            
+        }
+
+        assertCorrectHighlighted(Chunks.fillInChunks(combinedChunks, TEXT.length))
+        assertCorrectHighlighted(Chunks.findAll(["qui", "isquam"], TEXT))
+
+    })();
+
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,87 @@
+/**
+ * Creates an array of chunk objects representing both higlightable and non highlightable pieces of text that match each search word.
+ * @param searchWords string[]
+ * @param text string
+ * @return {start:number, end:number, highlight:boolean}[]
+ */
+export const findAll = (searchWords, text) =>
+  fillInChunks(
+    combineChunks(
+      findChunks(text, searchWords)
+    ),
+    text.length
+  )
+
+/**
+ * Takes an array of {start:number, end:number} objects and combines chunks that overlap into single chunks.
+ * @param chunks {start:number, end:number}[]
+ * @return {start:number, end:number}[]
+ */
+export const combineChunks = (chunks) => {
+  chunks = chunks
+    .sort((first, second) => first.start - second.start)
+    .reduce((processedChunks, nextChunk) => {
+      // First chunk just goes straight in the array...
+      if (processedChunks.length === 0) {
+        return [nextChunk]
+      } else {
+        // ... subsequent chunks get checked to see if they overlap...
+        const prevChunk = processedChunks.pop()
+        if (nextChunk.start <= prevChunk.end) {
+          // It may be the case that prevChunk completely surrounds nextChunk, so take the
+          // largest of the end indeces.
+          const endIndex = Math.max(prevChunk.end, nextChunk.end)
+          processedChunks.push({start: prevChunk.start, end: endIndex})
+        } else {
+          processedChunks.push(prevChunk, nextChunk)
+        }
+        return processedChunks
+      }
+    }, [])
+
+  return chunks
+}
+
+/**
+ * Examine textToSearch for any matches.
+ * If we find matches, add them to the returned array as a "chunk" object ({start:number, end:number}).
+ * @param textToSearch string
+ * @param wordsToFind string[]
+ * @return {start:number, end:number}[]
+ */
+export const findChunks = (textToSearch, wordsToFind) =>
+  wordsToFind
+    .filter(searchWord => searchWord) // Remove empty words
+    .reduce((chunks, searchWord) => {
+        const regex = new RegExp(searchWord, 'gi')
+        let match
+        while ((match = regex.exec(textToSearch)) != null) {
+          chunks.push({start: match.index, end: regex.lastIndex})
+        }
+        return chunks
+    }, [])
+
+/**
+ * Given a set of chunks to highlight, create an additional set of chunks
+ * to represent the bits of text between the highlighted text.
+ * @param chunksToHighlight {start:number, end:number}[]
+ * @param totalLength number
+ * @return {start:number, end:number, highlight:boolean}[]
+ */
+export const fillInChunks = (chunksToHighlight, totalLength) => {
+  const allChunks = []
+  const append = (start, end, highlight) => allChunks.push({start: start, end: end, highlight: highlight})
+
+  if (chunksToHighlight.length == 0) {
+	append(0, totalLength, false);
+  } else {
+    let lastIndex = 0
+    chunksToHighlight.forEach((chunk) => {
+      append(lastIndex, chunk.start, false)
+      append(chunk.start, chunk.end, true)
+      lastIndex = chunk.end
+    })
+    append(lastIndex, totalLength, false)
+  }
+  return allChunks
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,7 +73,7 @@ export const fillInChunks = (chunksToHighlight, totalLength) => {
   const append = (start, end, highlight) => allChunks.push({start: start, end: end, highlight: highlight})
 
   if (chunksToHighlight.length == 0) {
-	append(0, totalLength, false);
+    append(0, totalLength, false);
   } else {
     let lastIndex = 0
     chunksToHighlight.forEach((chunk) => {


### PR DESCRIPTION
Fixes #1 by doing a pass over the text to find all matching "chunks" for each search word. It then does a pass over these chunks to merge the ones which are overlapping. Finally, given a blob of text and a set of merged chunks, it creates chunks for each of the _non_-matching portions of the text. This resulting collection of matching and non-matching chunks then get used to identify each portion of the text as either a highlighted or a non-highlighted portion.

**Notes on tests:** I must apologise for not taking the time to learn whatever the testing framework you are using. I had some troubles getting it to run on my ArchLinux laptop for some reason. Anyhow, I did create a set of unit tests, and I tried to make it clear where each test starts/finishes by running them in an anonymous function. Hopefully it should be easy to extract these into proper tests for the JS testing framework of your choice.

In order to run these tests, I have a [silly branch](https://github.com/pserwylo/react-highlight-words/tree/combine-highlights--hacky-testing) with an extra commit. The tip of that branch runs the tests each time the `Highlighter` module is imported, and prints to the console if there are errors.