### PR TITLE
Reduce library size (by 37x)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+website
+node_modules
+karma.conf.js
+src
+webpack*

--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -13,11 +13,15 @@ module.exports = {
   },
   plugins: [
   ],
+  externals: {
+    "react": "React",
+  },
   module: {
     loaders: [
       {
         test: /\.js$/,
         loader: 'babel',
+        exclude: /(node_modules)/,
         include: path.join(__dirname, 'src')
       },
       {


### PR DESCRIPTION
I was running [webpack-bundle-size-analyzer](https://github.com/robertknight/webpack-bundle-size-analyzer) investigating why my bundle size was getting so big and I noticed your library was taking more space than React itself !
With some digging I figured you are actually including React with this package which isn't the expected behavior when React is already a dependency of the package. 

This PR adds adds React as an `externals` (see http://webpack.github.io/docs/library-and-externals.html) so that it's not included. 
`main.js` is now almost 37x smaller : 

Before: 
```
~/react-highlight-words $ ls -la dist/main.js
-rw-r--r--  1 loic  staff  695657 May 10 17:31 dist/main.js
```
After: 
```
 ~/react-highlight-words $ ls -la dist/main.js
-rw-r--r--  1 loic  staff  18826 May 10 17:34 dist/main.js
```

It also adds a `.npmignore` so unused files don't get included in the npm package