### PR TITLE
Do not include .babelrc in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ karma.conf.js
 src
 webpack*
 .idea
+.babelrc


### PR DESCRIPTION
An alternative solution to #19.  I'm guessing @untone is dealing with the same problem that I am - an inability to use react-highlight-words since it's .babelrc is for Babel 5 and we're using Babel 6.

See https://github.com/reactjs/redux/issues/1033 and https://github.com/gaearon/redux-thunk/pull/44 if more justification is required.