### PR TITLE
Allow the use of a class for the non highlighted

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ And the `Highlighter` will mark all occurrences of search terms within the text:
 |:---|:---|:---:|:---|
 | autoEscape | Boolean |  | Escape characters which are meaningful in regular expressions |
 | activeClassName | String |  | The class name to be applied to an active match. Use along with `activeIndex` |
+| inactiveClassName | String |  | The class name to be applied to all those unmatched words. |
 | activeIndex | String |  | Specify the match index that should be actively highlighted. Use along with `activeClassName` |
 | className | String |  | CSS class name applied to the outer/wrapper `<span>` |
 | highlightClassName | String |  | CSS class name applied to highlighted text |

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 Highlighter.propTypes = {
+  nonActiveClassName: PropTypes.string,
   activeClassName: PropTypes.string,
   activeIndex: PropTypes.string,
   autoEscape: PropTypes.bool,
@@ -21,6 +22,7 @@ Highlighter.propTypes = {
  * This function returns an array of strings and <span>s (wrapping highlighted words).
  */
 export default function Highlighter ({
+  nonActiveClassName = '',
   activeClassName = '',
   activeIndex = -1,
   autoEscape,
@@ -62,7 +64,7 @@ export default function Highlighter ({
           )
         } else {
           return (
-            <span key={index} className={className}>{text}</span>
+            <span key={index} className={nonActiveClassName}>{text}</span>
           )
         }
       })}

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -62,7 +62,7 @@ export default function Highlighter ({
           )
         } else {
           return (
-            <span key={index}>{text}</span>
+            <span key={index} className={className}>{text}</span>
           )
         }
       })}

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 Highlighter.propTypes = {
-  nonActiveClassName: PropTypes.string,
+  inactiveClassName: PropTypes.string,
   activeClassName: PropTypes.string,
   activeIndex: PropTypes.string,
   autoEscape: PropTypes.bool,
@@ -22,7 +22,7 @@ Highlighter.propTypes = {
  * This function returns an array of strings and <span>s (wrapping highlighted words).
  */
 export default function Highlighter ({
-  nonActiveClassName = '',
+  inactiveClassName = '',
   activeClassName = '',
   activeIndex = -1,
   autoEscape,
@@ -64,7 +64,7 @@ export default function Highlighter ({
           )
         } else {
           return (
-            <span key={index} className={nonActiveClassName}>{text}</span>
+            <span key={index} className={inactiveClassName}>{text}</span>
           )
         }
       })}


### PR DESCRIPTION
There is a issue that doesn’t allow the user use a specific class for
the elements that has no highlighted texts.