### PR TITLE
Multiple colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,11 @@ And the `Highlighter` will mark all occurrences of search terms within the text:
 | className | String |  | CSS class name applied to the outer/wrapper `<span>` |
 | caseSensitive | Boolean |  | Search should be case sensitive; defaults to `false` |
 | findChunks | Function |  | Use a custom function to search for matching chunks. This makes it possible to use arbitrary logic when looking for matches. See the default `findChunks` function in [highlight-words-core](https://github.com/bvaughn/highlight-words-core) for signature. Have a look at the [custom findChunks example](https://codesandbox.io/s/k20x3ox31o) on how to use it. |
-| highlightClassName | String |  | CSS class name applied to highlighted text |
+| highlightClassName | String or Object |  | CSS class name applied to highlighted text or object mapping text to class. |
 | highlightStyle | Object |  | Inline styles applied to highlighted text |
 | highlightTag | Node |  | Type of tag to wrap around highlighted matches; defaults to `mark` but can also be a React element (class or functional) |
 | sanitize | Function |  | Process each search word and text to highlight before comparing (eg remove accents); signature `(text: string): string` |
 | searchWords | Array<String> | ✓ | Array of search words. The search terms are treated as RegExps unless `autoEscape` is set. |
-| textColors | Object |  | Object with mappings of words to css class to be applied. This prop supercedes `highlightClassName` if that prop is given. |
 | textToHighlight | String | ✓ | Text to highlight matches in |
 | unhighlightClassName | String |  | CSS class name applied to unhighlighted text |
 | unhighlightStyle | Object |  | Inline styles applied to unhighlighted text |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ And the `Highlighter` will mark all occurrences of search terms within the text:
 | highlightTag | Node |  | Type of tag to wrap around highlighted matches; defaults to `mark` but can also be a React element (class or functional) |
 | sanitize | Function |  | Process each search word and text to highlight before comparing (eg remove accents); signature `(text: string): string` |
 | searchWords | Array<String> | ✓ | Array of search words. The search terms are treated as RegExps unless `autoEscape` is set. |
+| textColors | Object |  | Object with mappings of words to css class to be applied. This prop supercedes `highlightClassName` if that prop is given. |
 | textToHighlight | String | ✓ | Text to highlight matches in |
 | unhighlightClassName | String |  | CSS class name applied to unhighlighted text |
 | unhighlightStyle | Object |  | Inline styles applied to unhighlighted text |

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "dependencies": {
     "highlight-words-core": "^1.2.0",
+    "memoize-one": "^4.0.0",
     "prop-types": "^15.5.8"
   },
   "peerDependencies": {

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -19,6 +19,7 @@ Highlighter.propTypes = {
   ]),
   sanitize: PropTypes.func,
   searchWords: PropTypes.arrayOf(PropTypes.string).isRequired,
+  textColors: PropTypes.object,
   textToHighlight: PropTypes.string.isRequired,
   unhighlightClassName: PropTypes.string,
   unhighlightStyle: PropTypes.object
@@ -41,6 +42,7 @@ export default function Highlighter ({
   highlightTag = 'mark',
   sanitize,
   searchWords,
+  textColors,
   textToHighlight,
   unhighlightClassName = '',
   unhighlightStyle
@@ -66,9 +68,11 @@ export default function Highlighter ({
         if (chunk.highlight) {
           highlightCount++
 
+          const colorClass = textColors ? textColors[text] : undefined;
+
           const isActive = highlightCount === +activeIndex
 
-          highlightClassNames = `${highlightClassName} ${isActive ? activeClassName : ''}`
+          highlightClassNames = `${colorClass ? colorClass : highlightClassName} ${isActive ? activeClassName : ''}`
           highlightStyles = isActive === true && activeStyle != null
             ? Object.assign({}, highlightStyle, activeStyle)
             : highlightStyle

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -68,7 +68,16 @@ export default function Highlighter ({
         if (chunk.highlight) {
           highlightCount++
 
-          const colorClass = textColors ? textColors[text] : undefined;
+          if(textColors){
+            textColors = Object.keys(textColors).reduce((colors, x) => {
+              return {
+                ...colors,
+                [x.toLowerCase()]: textColors[x]
+              }
+            }, {})
+          }
+
+          const colorClass = textColors ? textColors[text.toLowerCase()] : undefined;
 
           const isActive = highlightCount === +activeIndex
 

--- a/src/Highlighter.test.js
+++ b/src/Highlighter.test.js
@@ -22,7 +22,8 @@ describe('Highlighter', () => {
     sanitize,
     searchWords,
     textToHighlight,
-    unhighlightStyle
+    unhighlightStyle,
+    highlightClassName
   }) {
     const node = render(
       <div>
@@ -33,7 +34,7 @@ describe('Highlighter', () => {
           autoEscape={autoEscape}
           caseSensitive={caseSensitive}
           findChunks={findChunks}
-          highlightClassName={HIGHLIGHT_CLASS}
+          highlightClassName={highlightClassName || HIGHLIGHT_CLASS}
           highlightStyle={highlightStyle}
           highlightTag={highlightTag}
           sanitize={sanitize}
@@ -300,5 +301,18 @@ describe('Highlighter', () => {
     })
     const matches2 = node2.querySelectorAll(HIGHLIGHT_QUERY_SELECTOR)
     expect(matches2).to.have.length(0)
+  })
+
+  it('should render chucks with the appropriate classes', () => {
+    const node = getHighlighterChildren({
+      searchWords: ['This', 'is', 'text'],
+      textToHighlight: 'This is text',
+      highlightClassName: { This: 'this', is: 'is', text: 'text'}
+    })
+    const allMatches = node.querySelectorAll('mark')
+    expect(allMatches).to.have.length(3)
+    expect(allMatches[0].classList).to.contain('this')
+    expect(allMatches[1].classList).to.contain('is')
+    expect(allMatches[2].classList).to.contain('text')
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,6 +3413,10 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
 
+memoize-one@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.0.tgz#fc5e2f1427a216676a62ec652cf7398cfad123db"
+
 memory-fs@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"


### PR DESCRIPTION
This change introduces a new `prop` called `textColors`. This new prop is a mapping of words to css classes and is used to apply these classes to the words.

For example: 
`{ the: 'green', of: 'blue', hello: 'orange' }`

In the example, instances of `the` will have the class `green` applied to them instead of `highlightClassName`.

Note: I had trouble running the tests due to an `npm install` problem, probably with `phantomjs`. I'm happy to take some advice on that to make sure that the tests still pass, because I was unable to do that.