### PR TITLE
Expose chunk, chunkIndex, and highlightIndex to highlightTag render prop

### DIFF
--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -106,9 +106,9 @@ export default function Highlighter ({
           return (
             <HighlightTag
               className={highlightClassNames}
+              highlightIndex={highlightCount}
               key={index}
               style={highlightStyles}
-              highlightIndex={highlightCount}
             >
               {text}
             </HighlightTag>


### PR DESCRIPTION
This change exposes the `chunk`, `index as chunkIndex`, and `highlightCount as highlightIndex` to the `HighlightTag` render prop. This is useful if a user would like to apply custom styling/colors to the chunks. It could be used like this for example:

```js
const getHighlightTag = () => ({ children, highlightIndex }) => {
    const backgroundColors: {
        0: 'green',
        1: 'red',
        2: 'blue
    }

    return (
        <mark backgroundColor={backgroundColors[highlightIndex]}>
            {children}
        </mark>
    );
};


<Highlighter
    highlightTag={getHighlightTag()}
    searchWords={[ 'hello', 'highlight', 'text' ]}
    textToHighlight={'hello, highlight this text'}
/>
```

The `chunk` and `chunkIndex` props are not necessary for the above example, but I thought they may be useful for someone