### PR TITLE
Remove --save

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ yarn add react-highlight-words
 ```
 
 ```
-npm i --save react-highlight-words
+npm i react-highlight-words
 ```
 
 ## License


### PR DESCRIPTION
The `--save` option of `npm install` is now assumed without it and no longer needed to be specified.