### PR TITLE
fix: set autoEscape to true on demo website 

### DIFF
--- a/src/Highlighter.example.js
+++ b/src/Highlighter.example.js
@@ -76,6 +76,7 @@ export default class HighlighterExample extends Component {
         <Highlighter
           activeClassName={styles.Active}
           activeIndex={activeIndex}
+          autoEscape={true}
           caseSensitive={caseSensitive}
           highlightClassName={styles.Highlight}
           highlightStyle={{ fontWeight: 'normal' }}


### PR DESCRIPTION
The demo website was crashing when you typed _[_ into **Search terms** box.

Had a discussion with [bvaughn](https://github.com/bvaughn) about setting the **autoEscape** param to **true** on highlight-words-core package, but as he said, changing the default value is going to have performance implications for current users.

![image](https://user-images.githubusercontent.com/21077089/221217430-d1bc5738-2f7f-449c-ac89-57d68e348d6f.png)
![image](https://user-images.githubusercontent.com/21077089/221217500-bba1b75a-518f-4c1d-b73d-19be259bd035.png)
