### PR TITLE
Replace Deprecated substr with substring in Highlighter.js

### DIFF
--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -87,7 +87,7 @@ export default function Highlighter ({
     className,
     ...rest,
     children: chunks.map((chunk, index) => {
-      const text = textToHighlight.substr(chunk.start, chunk.end - chunk.start)
+      const text = textToHighlight.substring(chunk.start, chunk.end)
 
       if (chunk.highlight) {
         highlightIndex++


### PR DESCRIPTION
# Summary
This pull request revises Highlighter.js by substituting the outdated [substr](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) method with [substring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring).

- [substr](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is no longer recommended and may have been removed from relevant web standards​​.
- [substring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) is part of the ECMAScript standard and is advised for consistent, future-proof code​​.

# Tests
- Existing tests continue to pass 